### PR TITLE
Typo Update translation.json

### DIFF
--- a/static/locales/en/translation.json
+++ b/static/locales/en/translation.json
@@ -68,7 +68,7 @@
       },
       "link2": {
         "title": "Examples",
-        "subtitle": "Gallery of collaborative experiencess"
+        "subtitle": "Gallery of collaborative experiences"
       },
       "link3": {
         "title": "Notification Quickstart",


### PR DESCRIPTION

<img width="488" alt="Снимок экрана 2024-11-07 в 21 02 53" src="https://github.com/user-attachments/assets/3c3d119b-d092-4ec9-82d7-d67951e3ee4a">


"experiencess" (in "link2": { "title": "Examples", "subtitle": "Gallery of collaborative experiencess" })

The word "experiencess" contains a typo: the correct form is "**experiences**".

Corrected.