### PR TITLE
Fix Typo in Documentation Files

### DIFF
--- a/docs/video/01-Intro-Push-Video.mdx
+++ b/docs/video/01-Intro-Push-Video.mdx
@@ -32,7 +32,7 @@ import {
 
 ## Why Push Video?
 
-Push Video brings native wallet to wallet (or multi-wallets) audio and video calling functionality. As a standalone offering or as part of [Push Group Chat](/docs/chat 'Techinal documentation on how to integrate Push Chat'). This enables a native, seamless web3 wallet first experience for real time communication and opens up the possibilites for —
+Push Video brings native wallet to wallet (or multi-wallets) audio and video calling functionality. As a standalone offering or as part of [Push Group Chat](/docs/chat 'Technical documentation on how to integrate Push Chat'). This enables a native, seamless web3 wallet first experience for real time communication and opens up the possibilites for —
 
 - **Video calling** without the user going to any other platform
 - **Web3 social real time calls**

--- a/docs/video/101-Build-Section.mdx
+++ b/docs/video/101-Build-Section.mdx
@@ -8,7 +8,7 @@ sidebar_position: 101
 image: "/assets/docs/previews/docs_video__section--build.png"
 ---
 
-# Get Buidling!
+# Get Building!
 
 This section covers everything you will require from Push SDK to create any functionality or features related to Push Notification.
 


### PR DESCRIPTION
#### Summary:
This pull request addresses and corrects two typos found in the documentation files `docs/video/01-Intro-Push-Video.mdx` and `docs/video/101-Build-Section.mdx`.

#### Changes:
1. **File: `docs/video/01-Intro-Push-Video.mdx`**
   - Fixed a typo where the word "Techinal" was used incorrectly. The correct spelling is "Technical."
   - **Before**: "As a standalone offering or as part of Push Group Chat."
   - **After**: "As a standalone offering or as part of Push Group Chat."

2. **File: `docs/video/101-Build-Section.mdx`**
   - Fixed a typo in the section title where the word "Buidling" was used instead of "Building."
   - **Before**:
     ```
     # Get Buidling!
     ```
   - **After**:
     ```
     # Get Building!
     ```

#### Importance:
These changes are important as they correct spelling errors that could lead to confusion or reduce the professionalism of the documentation. The correction in `01-Intro-Push-Video.mdx` ensures that the term "Technical" is spelled correctly, which is essential for clarity in technical communication. Similarly, correcting the title in `101-Build-Section.mdx` ensures consistency and prevents potential misunderstandings for users following the instructions.

#### Files Changed:
- `docs/video/01-Intro-Push-Video.mdx`
- `docs/video/101-Build-Section.mdx`