### PR TITLE
fix(deps): remove unused swiper to resolve Critical prototype pollution

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "stream-browserify": "3.0.0",
     "stream-http": "^3.2.0",
     "styled-components": "^6.0.8",
-    "swiper": "^11.0.3",
     "tweetnacl": "^1.0.3",
     "typewriter-effect": "^2.21.0",
     "undici": "5.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16431,11 +16431,6 @@ svgo@^3.0.2, svgo@^3.2.0:
     picocolors "^1.0.0"
     sax "^1.5.0"
 
-swiper@^11.0.3:
-  version "11.2.10"
-  resolved "https://registry.yarnpkg.com/swiper/-/swiper-11.2.10.tgz#ed0b17286b56f7fe8d4b46ed61e6e0bd8daaccad"
-  integrity sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==
-
 swr@^2.2.4:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/swr/-/swr-2.4.1.tgz#c9e48abff6bf4b04846342e2f1f6be108a078cf6"


### PR DESCRIPTION
swiper@11.2.10 carried a Critical prototype pollution advisory (GHSA-hmx5-qpq5-p643, CVSS 9.4) affecting swiper >=6.5.1, <12.1.2.

The package was a direct dependency but had zero imports or references anywhere in the codebase, and nothing else in the tree depended on it (single leaf entry in yarn.lock). Removing it eliminates the vulnerability without a risky major upgrade (11 to 12) of unused code.

- package.json: drop "swiper": "^11.0.3"
- yarn.lock: remove the swiper@^11.0.3 entry (leaf, no sub-deps)